### PR TITLE
removing final private to avoid warnings in php 8

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -229,7 +229,7 @@ class Frame
     /**
      * @return string
      */
-    final private function getFrame()
+    private function getFrame()
     {
         $lines = new \ArrayObject();
         $lines->append($this->command . self::BYTE['LF']);


### PR DESCRIPTION
I am using this class in php 8.2 and works fine but I get a warning that can be avoided removing final.